### PR TITLE
[refactor #18] Google Map 조회 리뷰 총합 수, 웹사이트 주소 컬럼 포함

### DIFF
--- a/src/main/java/com/wellcome/WellcomeBE/domain/review/PlaceReviewResponse.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/review/PlaceReviewResponse.java
@@ -16,7 +16,9 @@ public class PlaceReviewResponse {
         private String name;                     // 장소 이름
         private OpeningHours opening_hours;      // 운영 시간
         private double rating;                   // 평점
-        private List<PlaceReview> reviews;       // 리뷰 리스트
+        private List<PlaceReview> reviews;      // 리뷰 리스트
+        private int user_ratings_total;         // 총 리뷰 갯수
+        private String website;                 // 웹사이트 정보
 
         @Data
         public static class OpeningHours {

--- a/src/main/java/com/wellcome/WellcomeBE/domain/review/ReviewService.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/review/ReviewService.java
@@ -118,7 +118,7 @@ public class ReviewService {
         return webClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path("details/json")
-                        .queryParam("fields", "name,rating,formatted_phone_number,opening_hours,reviews")
+                        .queryParam("fields", "name,rating,formatted_phone_number,opening_hours,website,user_ratings_total,reviews")
                         .queryParam("place_id", placeId)
                         .queryParam("language", "ko")
                         .queryParam("key", apiKey)


### PR DESCRIPTION
## 🔎 Description
-Google Map 조회 리뷰 총합 수, 웹사이트 주소 컬럼 포함

## 💭 Issue
- closed #18 

## 🗝 Key Changes
<!-- 주요 변경사항에 대해 작성해 주세요 -->
- user_ratings_total 추가: 사용자가 남긴 총 평점의 수. 즉, 평점을 남긴 총 인원 수를 의미합니다. 해당 컬럼을 작성된 리뷰 수로 사용하고자 합니다.
-website 정보 추가
![image](https://github.com/user-attachments/assets/799574a8-2200-471d-9bff-ed06b4fb8315)


## 🙏 To Reviewers
<!-- 리뷰어 전달사항을 작성해 주세요 -->
user_ratings_total 값이 0인 경우가 발생해서, 기존 로직에 포함하지 않았습니다. 해당 컬럼의 필요성에 대해 고민해주세요!
![image](https://github.com/user-attachments/assets/711fc315-175f-4676-a9be-0ab0587b3175)


