### PR TITLE
[Feat #30] 사용자 프로필 조회 로직 구현

### DIFF
--- a/src/main/java/com/wellcome/WellcomeBE/domain/member/controller/MemberController.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.wellcome.WellcomeBE.domain.member.controller;
 
 import com.wellcome.WellcomeBE.domain.member.dto.request.LogoutRequest;
 import com.wellcome.WellcomeBE.domain.member.dto.response.LoginResponse;
+import com.wellcome.WellcomeBE.domain.member.dto.response.MemberProfileResponse;
 import com.wellcome.WellcomeBE.domain.member.service.MemberService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -12,29 +13,34 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/api/oauth2/kakao")
 public class MemberController {
 
     private final MemberService memberService;
 
     // 카카오 로그인
-    @GetMapping
+    @GetMapping("/api/oauth2/kakao")
     public ResponseEntity<LoginResponse> kakaoLogin(@RequestParam("code") String code){
         return ResponseEntity.ok(memberService.handleKakaoLogin(code));
     }
 
     // 토큰 갱신
-    @PostMapping("/refresh")
+    @PostMapping("/api/oauth2/kakao/refresh")
     public ResponseEntity<LoginResponse> kakaoRenewToken(HttpServletRequest httpServletRequest){
         return ResponseEntity.ok(memberService.renewKakaoToken(httpServletRequest));
     }
 
     // 카카오 로그아웃
-    @PostMapping("/logout")
+    @PostMapping("/api/oauth2/kakao/logout")
     public ResponseEntity<Void> kakaoLogout(HttpServletRequest httpServletRequest,
                                             @RequestBody LogoutRequest logoutRequest){
         memberService.handleKakaoLogout(httpServletRequest, logoutRequest.getRefreshToken());
         return ResponseEntity.ok().build();
+    }
+
+    // 사용자 프로필 조회
+    @GetMapping("/api/mypage/profile")
+    public ResponseEntity<MemberProfileResponse> getMemberProfile(){
+        return ResponseEntity.ok(memberService.getMemberProfile());
     }
 
 }

--- a/src/main/java/com/wellcome/WellcomeBE/domain/member/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/member/dto/response/MemberProfileResponse.java
@@ -1,0 +1,23 @@
+package com.wellcome.WellcomeBE.domain.member.dto.response;
+
+import com.wellcome.WellcomeBE.domain.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MemberProfileResponse {
+
+    private Long memberId;
+    private String nickname;
+    private String profileImgUrl;
+
+    public static MemberProfileResponse from(Member member){
+        return MemberProfileResponse.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .profileImgUrl(member.getProfileImg())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wellcome/WellcomeBE/domain/member/service/MemberService.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.wellcome.WellcomeBE.domain.member.service;
 
 import com.wellcome.WellcomeBE.domain.member.Member;
+import com.wellcome.WellcomeBE.domain.member.dto.response.MemberProfileResponse;
 import com.wellcome.WellcomeBE.domain.member.repository.MemberRepository;
 import com.wellcome.WellcomeBE.domain.member.dto.response.KakaoTokenResponse;
 import com.wellcome.WellcomeBE.domain.member.dto.response.KakaoUserInfoResponse;
@@ -16,8 +17,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
-import static com.wellcome.WellcomeBE.global.exception.CustomErrorCode.REFRESH_TOKEN_EXPIRED;
-import static com.wellcome.WellcomeBE.global.exception.CustomErrorCode.TOKEN_MISSING;
+import static com.wellcome.WellcomeBE.global.exception.CustomErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -111,6 +111,17 @@ public class MemberService {
 
         // SecurityContextHolder 초기화
         tokenProvider.clearContext();
+    }
+
+    /**
+     * 사용자 프로필 조회
+     */
+    public MemberProfileResponse getMemberProfile() {
+
+        Member member = memberRepository.findById(tokenProvider.getMemberId())
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+
+        return MemberProfileResponse.from(member);
     }
 
 }


### PR DESCRIPTION
## 🔎 Description
- 사용자 프로필 조회 로직 구현

## 💭 Issue
- closed #30 

## 🗝 Key Changes
<!-- 주요 변경사항에 대해 작성해 주세요 -->
- 닉네임, 프로필 이미지의 경우 카카오에서 제공하는 정보를 사용합니다.
- 프로필 이미지가 기본 이미지일 경우, null을 반환합니다.
![image](https://github.com/user-attachments/assets/20f34c34-b207-4576-8b12-28bcc42dc957)


