### PR TITLE
[Feat #23] 웰니스 장소 추천 목록 조회 기본 로직 구현 (로그인 가정)

### DIFF
--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/repository/WellnessInfoRepository.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/repository/WellnessInfoRepository.java
@@ -5,7 +5,7 @@ import com.wellcome.WellcomeBE.domain.wellnessInfo.WellnessInfo;
 import com.wellcome.WellcomeBE.global.type.Sigungu;
 import com.wellcome.WellcomeBE.global.type.Thema;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,7 +14,10 @@ import java.util.List;
 
 public interface WellnessInfoRepository extends JpaRepository<WellnessInfo, Long> {
 
-    // [목록 조회] - 로그인한 경우
+    /**
+     * 목록 조회
+     */
+    // 테마나 지역을 모두 선택한 경우
     @Query(
             "SELECT w, " +
                 "CASE WHEN l.id IS NOT NULL THEN TRUE ELSE FALSE END " +
@@ -23,24 +26,82 @@ public interface WellnessInfoRepository extends JpaRepository<WellnessInfo, Long
             "WHERE w.thema IN :themaList AND w.sigungu IN :sigunguList " +
             "ORDER BY w.view DESC"
     )
-    Page<Object[]> findByThemaAndSigungu(PageRequest pageRequest,
-                                             @Param("member") Member member,
-                                             @Param("themaList") List<Thema> themaList,
-                                             @Param("sigunguList") List<Sigungu> sigunguList);
-
-    // [목록 조회] - 로그인 하지 않은 경우
-    @Query(
-            "SELECT w " +
-            "FROM WellnessInfo w " +
-            //"WHERE w.thema IN :themaList AND w.sigungu IN :sigunguList"
-            "WHERE (:themaList IS NULL OR w.thema IN :themaList) " +
-            "AND (:sigunguList IS NULL OR w.sigungu IN :sigunguList) " +
-            "ORDER BY w.view DESC"
-    )
-    Page<WellnessInfo> findByThemaAndSigunguWithoutLikes(PageRequest pageRequest,
+    Page<Object[]> findByThemaAndSigungu(Pageable pageable,
+                                         @Param("member") Member member,
                                          @Param("themaList") List<Thema> themaList,
                                          @Param("sigunguList") List<Sigungu> sigunguList);
 
+    // 테마, 지역 모두 선택하지 않은 경우
+    @Query("SELECT w, " +
+                "CASE WHEN l.id IS NOT NULL THEN TRUE ELSE FALSE END " +
+            "FROM WellnessInfo w " +
+            "LEFT JOIN Liked l ON l.wellnessInfo = w AND l.member = :member " +
+            "ORDER BY w.view DESC")
+    Page<Object[]> findAllByOrderByViewDesc(Pageable pageable,
+                                            @Param("member") Member member);
 
+    // 테마만 선택한 경우
+    @Query("SELECT w, " +
+                "CASE WHEN l.id IS NOT NULL THEN TRUE ELSE FALSE END " +
+            "FROM WellnessInfo w " +
+            "LEFT JOIN Liked l ON l.wellnessInfo = w AND l.member = :member " +
+            "WHERE w.thema IN :themaList " +
+            "ORDER BY w.view DESC")
+    Page<Object[]> findByThema(Pageable pageable,
+                               @Param("member") Member member,
+                               @Param("themaList") List<Thema> themaList);
+
+    // 지역만 선택한 경우
+    @Query("SELECT w, " +
+                "CASE WHEN l.id IS NOT NULL THEN TRUE ELSE FALSE END " +
+            "FROM WellnessInfo w " +
+            "LEFT JOIN Liked l ON l.wellnessInfo = w AND l.member = :member " +
+            "WHERE w.sigungu IN :sigunguList " +
+            "ORDER BY w.view DESC")
+    Page<Object[]> findBySigungu(Pageable pageable,
+                                 @Param("member") Member member,
+                                 @Param("sigunguList") List<Sigungu> sigunguList);
+
+    /**
+     * 테마, 지역 조회
+     */
+
+    // 테마, 지역 모두 선택한 경우
+    @Query(
+            "SELECT DISTINCT w.thema, w.sigungu " +
+            "FROM WellnessInfo w " +
+            "WHERE w.thema IN :themaList AND w.sigungu IN :sigunguList"
+    )
+    List<Object[]> findDistinctThemaAndSigungu(
+            @Param("themaList") List<Thema> themaList,
+            @Param("sigunguList") List<Sigungu> sigunguList
+    );
+
+    // 테마, 지역 모두 선택하지 않은 경우
+    @Query(
+            "SELECT DISTINCT w.thema, w.sigungu " +
+            "FROM WellnessInfo w"
+    )
+    List<Object[]> findDistinctAllThemaAndSigungu();
+
+    // 테마만 선택한 경우
+    @Query(
+            "SELECT DISTINCT w.thema, w.sigungu " +
+            "FROM WellnessInfo w " +
+            "WHERE w.thema IN :themaList"
+    )
+    List<Object[]> findDistinctThemaAndSigunguByThema(
+            @Param("themaList") List<Thema> themaList
+    );
+
+    // 지역만 선택한 경우
+    @Query(
+            "SELECT DISTINCT w.thema, w.sigungu " +
+            "FROM WellnessInfo w " +
+            "WHERE w.sigungu IN :sigunguList"
+    )
+    List<Object[]> findDistinctThemaAndSigunguBySigungu(
+            @Param("sigunguList") List<Sigungu> sigunguList
+    );
 
 }


### PR DESCRIPTION
## 🔎 Description
- 웰니스 장소 추천 목록 조회

## 💭 Issue
- #23 

## 🗝 Key Changes
<!-- 주요 변경사항에 대해 작성해 주세요 -->
![image](https://github.com/user-attachments/assets/ec6cef08-2551-4dbe-9945-9b37ac32393b)
![image](https://github.com/user-attachments/assets/bedff9ea-d35f-464b-9430-781f40773158)


## 🙏 To Reviewers
<!-- 리뷰어 전달사항을 작성해 주세요 -->
- 현재 모든 기능 로그인 필수라고 가정하고 구현했습니다. 
- 연동 일정이 급해, 조건을 매우 단순화해서 API 연동 테스트가 가능한 정도로만 구현해둔 상태입니다. 해당 API는 연동 테스트 후, 제일 먼저 수정하도록 하겠습니다.! (기존에 구현한 로직도 Querydsl 적용해서 리팩토링 할 예정입니다.)
- 현재 적용한 조건
  - 기본적으로, themaList, sigunguList 를 통해 필터링 합니다. (정렬 조건: 조회수 높은 순)
  - themaList, sigunguList 를 모두 선택하지 않았을 경우, 모든 데이터를 반환합니다. (정렬 조건: 조회수 높은 순)
