### PR TITLE
[Feat] 공공데이터포털 기상청 API를 활용하여 웰니스 장소 날씨 정보 추가

### DIFF
--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/controller/WellnessInfoController.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/controller/WellnessInfoController.java
@@ -69,10 +69,10 @@ public class WellnessInfoController {
         return ResponseEntity.ok(wellnessInfoApiService.getWellnessInfoGoogleReviews(wellnessInfoId));
     }
 
-    // 현재 날씨 정보 조회
+    // 현재 날씨 정보 조회 (강원도 날씨 테스트용)
     @GetMapping("/api/weather-info")
     public ResponseEntity<WeatherResponse> getWeatherInfo() {
-        return ResponseEntity.ok(wellnessInfoService.fetchWeatherInfo());
+        return ResponseEntity.ok(wellnessInfoService.fetchWeatherInfo(73, 134)); //강원도
     }
 
 }

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/controller/WellnessInfoController.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/controller/WellnessInfoController.java
@@ -8,7 +8,9 @@ import com.wellcome.WellcomeBE.global.type.ImgSavedType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
 
+import java.net.URISyntaxException;
 import java.util.List;
 
 @RestController
@@ -65,6 +67,12 @@ public class WellnessInfoController {
             @PathVariable("wellnessInfoId") Long wellnessInfoId
     ){
         return ResponseEntity.ok(wellnessInfoApiService.getWellnessInfoGoogleReviews(wellnessInfoId));
+    }
+
+    // 현재 날씨 정보 조회
+    @GetMapping("/api/weather-info")
+    public ResponseEntity<WeatherResponse> getWeatherInfo() {
+        return ResponseEntity.ok(wellnessInfoService.fetchWeatherInfo());
     }
 
 }

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WeatherApiResponse.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WeatherApiResponse.java
@@ -1,0 +1,51 @@
+package com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class WeatherApiResponse {
+
+    private Response response;
+
+    @Data
+    public static class Response {
+
+        private Header header;
+        private Body body;
+
+        @Data
+        public static class Header {
+            private String resultCode;
+            private String resultMsg;
+        }
+
+        @Data
+        public static class Body {
+            private String dataType;
+            private Items items;
+            private int numOfRows;
+            private int pageNo;
+            private int totalCount;
+
+            @Data
+            public static class Items {
+                private List<Item> item;
+
+                @Data
+                public static class Item {
+                    private String baseDate;
+                    private String baseTime;
+                    private String nx;
+                    private String ny;
+                    private String category;
+                    private String fcstDate;
+                    private String fcstTime;
+                    private String fcstValue;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WeatherResponse.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WeatherResponse.java
@@ -18,9 +18,6 @@ public class WeatherResponse {
 
     private String temperature; // 기온
     private String state; // 날씨 상태값
-    //private String skyState; // 하늘 상태
-    //private String precipitation; // 강수 형태
-    //private String hourlyPrecipitation; // 1시간 강수량
 
     public static WeatherResponse from (
             Map<String, String> values
@@ -31,9 +28,6 @@ public class WeatherResponse {
         return WeatherResponse.builder()
                 .temperature(values.get("T1H"))
                 .state(getWeatherState(sky, pty))
-                //.skyState(SkyStateType.getNameByCode(values.get("SKY")))
-                //.precipitation(PrecipitationType.getNameByCode(values.get("PTY")))
-                //.hourlyPrecipitation(values.get("RN1"))
                 .build();
     }
 

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WeatherResponse.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WeatherResponse.java
@@ -4,26 +4,64 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
+
+import static com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response.WeatherResponse.PrecipitationType.*;
+import static com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response.WeatherResponse.SkyStateType.CLEAR;
+import static com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response.WeatherResponse.SkyStateType.OVERCAST;
 
 @Getter
 @Builder
 public class WeatherResponse {
 
     private String temperature; // 기온
-    private String skyState; // 하늘 상태
-    private String precipitation; // 강수 형태
-    private String hourlyPrecipitation; // 1시간 강수량
+    private String state; // 날씨 상태값
+    //private String skyState; // 하늘 상태
+    //private String precipitation; // 강수 형태
+    //private String hourlyPrecipitation; // 1시간 강수량
 
     public static WeatherResponse from (
             Map<String, String> values
     ){
+        SkyStateType sky = SkyStateType.getTypeByCode(values.get("SKY"));
+        PrecipitationType pty = PrecipitationType.getTypeByCode(values.get("PTY"));
+
         return WeatherResponse.builder()
                 .temperature(values.get("T1H"))
-                .skyState(SkyStateType.getNameByCode(values.get("SKY")))
-                .precipitation(PrecipitationType.getNameByCode(values.get("PTY")))
-                .hourlyPrecipitation(values.get("RN1"))
+                .state(getWeatherState(sky, pty))
+                //.skyState(SkyStateType.getNameByCode(values.get("SKY")))
+                //.precipitation(PrecipitationType.getNameByCode(values.get("PTY")))
+                //.hourlyPrecipitation(values.get("RN1"))
                 .build();
+    }
+
+    private static String getWeatherState(SkyStateType sky, PrecipitationType pty){
+
+        // SkyStateType이 CLEAR인 경우: 맑음 처리
+        if (sky == CLEAR){
+            return CLEAR.getName();
+        }
+
+        // PrecipitationType이 NONE인 경우: 흐림 처리
+        if (pty == NONE) {
+            return OVERCAST.getName();
+        }
+
+        // 강수 상태에 따른 처리
+        switch (pty){
+            case RAIN :
+            case DRIZZLE:
+                return RAIN.getName(); // 비
+            case RAIN_SNOW:
+            case DRIZZLE_SNOW:
+                return RAIN_SNOW.getName(); // 비/눈
+            case SNOW:
+            case SNOW_FLURRIES:
+                return SNOW.getName(); // 눈
+        }
+        return null;
     }
 
     // 하늘 상태
@@ -37,13 +75,11 @@ public class WeatherResponse {
         private final String name;
         private final String code;
 
-        public static String getNameByCode(String code) {
-            for (SkyStateType type : SkyStateType.values()) {
-                if (type.getCode().equals(code)) {
-                    return type.getName();
-                }
-            }
-            return null;
+        public static SkyStateType getTypeByCode(String code) {
+            return Arrays.stream(SkyStateType.values())
+                    .filter(type -> Objects.equals(type.getCode(), code))
+                    .findFirst()
+                    .orElse(null);
         }
     }
 
@@ -62,13 +98,11 @@ public class WeatherResponse {
         private final String name;
         private final String code;
 
-        public static String getNameByCode(String code) {
-            for (PrecipitationType type : PrecipitationType.values()) {
-                if (type.getCode().equals(code)) {
-                    return type.getName();
-                }
-            }
-            return null;
+        public static PrecipitationType getTypeByCode(String code) {
+            return Arrays.stream(PrecipitationType.values())
+                    .filter(type -> type.getCode().equals(code))
+                    .findFirst()
+                    .orElse(null);
         }
     }
 }

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WeatherResponse.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WeatherResponse.java
@@ -1,0 +1,74 @@
+package com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class WeatherResponse {
+
+    private String temperature; // 기온
+    private String skyState; // 하늘 상태
+    private String precipitation; // 강수 형태
+    private String hourlyPrecipitation; // 1시간 강수량
+
+    public static WeatherResponse from (
+            Map<String, String> values
+    ){
+        return WeatherResponse.builder()
+                .temperature(values.get("T1H"))
+                .skyState(SkyStateType.getNameByCode(values.get("SKY")))
+                .precipitation(PrecipitationType.getNameByCode(values.get("PTY")))
+                .hourlyPrecipitation(values.get("RN1"))
+                .build();
+    }
+
+    // 하늘 상태
+    @Getter
+    @RequiredArgsConstructor
+    public enum SkyStateType {
+        CLEAR("맑음", "1"),
+        CLOUDY("구름 많음", "3"),
+        OVERCAST("흐림", "4");
+
+        private final String name;
+        private final String code;
+
+        public static String getNameByCode(String code) {
+            for (SkyStateType type : SkyStateType.values()) {
+                if (type.getCode().equals(code)) {
+                    return type.getName();
+                }
+            }
+            return null;
+        }
+    }
+
+    // 강수 형태
+    @Getter
+    @RequiredArgsConstructor
+    public enum PrecipitationType {
+        NONE("강수없음", "0"),
+        RAIN("비", "1"),
+        RAIN_SNOW("비/눈", "2"),
+        SNOW("눈", "3"),
+        DRIZZLE("빗방울", "5"),
+        DRIZZLE_SNOW("빗방울눈날림", "6"),
+        SNOW_FLURRIES("눈날림", "7");
+
+        private final String name;
+        private final String code;
+
+        public static String getNameByCode(String code) {
+            for (PrecipitationType type : PrecipitationType.values()) {
+                if (type.getCode().equals(code)) {
+                    return type.getName();
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WellnessInfoBasicResponse.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/dto/response/WellnessInfoBasicResponse.java
@@ -26,6 +26,7 @@ public class WellnessInfoBasicResponse {
     private String openDetail;
     private String tel;
     private String website;
+    private WeatherResponse weather;
 
     public static final String NO_INFO = "정보 없음";
 
@@ -33,7 +34,8 @@ public class WellnessInfoBasicResponse {
             WellnessInfo wellness,
             List<String> wellnessInfoImg,
             PlaceReviewResponse.PlaceResult placeResult,
-            boolean isLiked
+            boolean isLiked,
+            WeatherResponse weather
     ) {
         // 영업시간 정보
         String openDetail = placeResult != null ? OpeningHoursUtils.getOpenStatus(placeResult).getOpenDetail() : NO_INFO;
@@ -53,6 +55,7 @@ public class WellnessInfoBasicResponse {
                 .openDetail(openDetail)
                 .tel(wellness.getTel())
                 .website(placeResult != null ? placeResult.getWebsite() : "")
+                .weather(weather)
                 .build();
     }
 

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/service/WellnessInfoApiService.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/service/WellnessInfoApiService.java
@@ -6,10 +6,7 @@ import com.wellcome.WellcomeBE.domain.review.GoogleMapInfoService;
 import com.wellcome.WellcomeBE.domain.review.PlaceReviewResponse;
 import com.wellcome.WellcomeBE.domain.wellnessInfo.WellnessInfo;
 import com.wellcome.WellcomeBE.domain.wellnessInfo.dto.request.WellnessInfoListRequest;
-import com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response.WellnessInfoBasicResponse;
-import com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response.WellnessInfoGoogleReviewResponse;
-import com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response.WellnessInfoNearbyList;
-import com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response.WellnessInfoResponse;
+import com.wellcome.WellcomeBE.domain.wellnessInfo.dto.response.*;
 import com.wellcome.WellcomeBE.domain.wellnessInfo.repository.WellnessInfoRepository;
 import com.wellcome.WellcomeBE.domain.wellnessInfoImg.repository.WellnessInfoImgRepository;
 import com.wellcome.WellcomeBE.global.exception.CustomErrorCode;
@@ -42,6 +39,7 @@ public class WellnessInfoApiService {
     private final GoogleMapInfoService googleMapInfoService;
     private final LikedRepository likedRepository;
     private final WellnessInfoImgRepository wellnessInfoImgRepository;
+    private final WellnessInfoService wellnessInfoService;
 
 
     /**
@@ -102,8 +100,7 @@ public class WellnessInfoApiService {
      */
     @Transactional
     public WellnessInfoBasicResponse getWellnessInfoBasic(Long wellnessInfoId){
-
-
+        
         // 1. 웰니스 정보 가져오기
         WellnessInfo wellness = wellnessInfoRepository.findById(wellnessInfoId)
                  .orElseThrow(() -> new CustomException(CustomErrorCode.WELLNESS_INFO_NOT_FOUND));
@@ -117,10 +114,14 @@ public class WellnessInfoApiService {
         List<String> wellnessInfoImg = wellnessInfoImgRepository.findByWellnessInfo(wellness);
         boolean liked = likedRepository.existsByWellnessInfoAndMember(wellness, tokenProvider.getMember());
 
+        // 4. 시군구 날씨 정보 가져오기
+        Sigungu sigungu = wellness.getSigungu();
+        WeatherResponse weatherInfo = wellnessInfoService.fetchWeatherInfo(sigungu.getNx(), sigungu.getNy());
+
         // 조회 수 추가
         wellness.updateViewNum();
 
-        return WellnessInfoBasicResponse.from(wellness,wellnessInfoImg,placeResult,liked);
+        return WellnessInfoBasicResponse.from(wellness,wellnessInfoImg,placeResult,liked, weatherInfo);
     }
 
     /**

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/service/WellnessInfoService.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/service/WellnessInfoService.java
@@ -278,7 +278,7 @@ public class WellnessInfoService {
     /**
      * 웰니스 장소별 날씨 정보 제공 - 기상청 초단기예보 API 조회
      */
-     public WeatherResponse fetchWeatherInfo() {
+     public WeatherResponse fetchWeatherInfo(int nx, int ny) {
 
          // 발표 날짜, 발표 시각 설정
          String releaseDate = WeatherUtils.getReleaseDate();
@@ -292,8 +292,8 @@ public class WellnessInfoService {
          params.put("pageNo", String.valueOf(1));
          params.put("base_date", releaseDate);
          params.put("base_time", releaseTime);
-         params.put("nx", String.valueOf(73)); //강원도 설정
-         params.put("ny", String.valueOf(134));
+         params.put("nx", String.valueOf(nx));
+         params.put("ny", String.valueOf(ny));
 
          String uriString = webClientConfig.getWeatherApiUrl(params);
          Mono<WeatherApiResponse> weatherApiResponse;

--- a/src/main/java/com/wellcome/WellcomeBE/global/WeatherUtils.java
+++ b/src/main/java/com/wellcome/WellcomeBE/global/WeatherUtils.java
@@ -1,0 +1,33 @@
+package com.wellcome.WellcomeBE.global;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class WeatherUtils {
+
+    // 발표 날짜
+    public static String getReleaseDate(){
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        if(currentDateTime.getHour() == 0 && currentDateTime.getMinute() < 45){ //00:45 이전
+            return LocalDate.now().minusDays(1).format(formatter);
+        }else{
+            return LocalDate.now().format(formatter);
+        }
+    }
+
+    // 발표 시각
+    public static String getReleaseTime(){
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        int currentHour = currentDateTime.getHour();
+        int currentMinute = currentDateTime.getMinute();
+
+        if(currentMinute < 45){
+            currentHour -= 1;
+        }
+
+        return String.format("%02d30", currentHour); //HH30 형태로 반환
+    }
+}

--- a/src/main/java/com/wellcome/WellcomeBE/global/WeatherUtils.java
+++ b/src/main/java/com/wellcome/WellcomeBE/global/WeatherUtils.java
@@ -28,6 +28,11 @@ public class WeatherUtils {
             currentHour -= 1;
         }
 
+        // currentHour 0 -> -1로 감소할 경우 (00:00~00:44)
+        if (currentHour < 0) {
+            currentHour = 23;
+        }
+
         return String.format("%02d30", currentHour); //HH30 형태로 반환
     }
 }

--- a/src/main/java/com/wellcome/WellcomeBE/global/config/TourInfoApiWebClientConfig.java
+++ b/src/main/java/com/wellcome/WellcomeBE/global/config/TourInfoApiWebClientConfig.java
@@ -1,6 +1,5 @@
 package com.wellcome.WellcomeBE.global.config;
 
-import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -8,8 +7,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 @Configuration
 @Slf4j
@@ -19,6 +16,7 @@ public class TourInfoApiWebClientConfig {
     private String apiKey;
 
     private static final String TOUR_API_BASE_URL = "http://apis.data.go.kr/B551011/KorService1/";
+    private static final String WEATHER_API_BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtFcst";
 
     // WebClient 생성
     @Bean
@@ -65,4 +63,16 @@ public class TourInfoApiWebClientConfig {
     public String getServiceKey() {
         return apiKey;
     }
+
+    /**
+     * 기상청_단기예보 API (초단기예보 조회)
+     */
+    public String getWeatherApiUrl(Map<String, String> additionalParams){
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(WEATHER_API_BASE_URL)
+                .queryParam("serviceKey", apiKey)
+                .queryParam("dataType", "JSON");
+        additionalParams.forEach(uriBuilder::queryParam);
+        return uriBuilder.build(true).toUriString();
+    }
+
 }

--- a/src/main/java/com/wellcome/WellcomeBE/global/exception/CustomErrorCode.java
+++ b/src/main/java/com/wellcome/WellcomeBE/global/exception/CustomErrorCode.java
@@ -51,7 +51,10 @@ public enum CustomErrorCode {
     TOKEN_MISSING(UNAUTHORIZED, 9001, "토큰이 누락되었습니다."),
     REFRESH_TOKEN_EXPIRED(UNAUTHORIZED, 9002, "인증이 만료되었습니다. 다시 로그인하세요."),
     AUTHENTICATION_NOT_FOUND(UNAUTHORIZED, 9003, "인증 정보를 찾을 수 없습니다."),
-    KAKAO_LOGIN_CLIENT_ERROR(UNAUTHORIZED, 9004, "카카오 로그인 API 호출 오류 (Client Error)")
+    KAKAO_LOGIN_CLIENT_ERROR(UNAUTHORIZED, 9004, "카카오 로그인 API 호출 오류 (Client Error)"),
+
+    // 기상청 단기예보 API (10xxx)
+    WEATHER_API_RESPONSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,10001, "기상청 단기예보 API 응답값이 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/wellcome/WellcomeBE/global/security/SecurityConfig.java
+++ b/src/main/java/com/wellcome/WellcomeBE/global/security/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                             .requestMatchers("/{place}/details").permitAll()
                             .requestMatchers("/place/id").permitAll()
                             .requestMatchers("/api/home").permitAll()
+                            .requestMatchers("/api/weather-info").permitAll()
                             .anyRequest().authenticated();
                 })
 

--- a/src/main/java/com/wellcome/WellcomeBE/global/type/Sigungu.java
+++ b/src/main/java/com/wellcome/WellcomeBE/global/type/Sigungu.java
@@ -12,27 +12,30 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum Sigungu {
 
-    GANGNEUNG("강릉시", 1),
-    GOSEONG("고성군", 2),
-    DONGHAE("동해시", 3),
-    SAMCHEOK("삼척시", 4),
-    SOKCHO("속초시", 5),
-    YANGGU("양구군", 6),
-    YANGYANG("양양군", 7),
-    YEONGWOL("영월군", 8),
-    WONJU("원주시", 9),
-    INJE("인제군", 10),
-    JEONGSEON("정선군", 11),
-    CHEORWON("철원군", 12),
-    CHUNCHEON("춘천시", 13),
-    TAEBAEK("태백시", 14),
-    PYEONGCHANG("평창군", 15),
-    HONGCHEON("홍천군", 16),
-    HWACHEON("화천군", 17),
-    HOENGSEONG("횡성군", 18);
+    GANGNEUNG("강릉시", 1, 92, 131),
+    GOSEONG("고성군", 2, 85, 145),
+    DONGHAE("동해시", 3, 97, 127),
+    SAMCHEOK("삼척시", 4, 98, 125),
+    SOKCHO("속초시", 5, 87, 141),
+    YANGGU("양구군", 6, 77, 139),
+    YANGYANG("양양군",7, 88, 138),
+    YEONGWOL("영월군", 8, 86, 119),
+    WONJU("원주시", 9, 76, 122),
+    INJE("인제군", 10, 80, 138),
+    JEONGSEON("정선군", 11, 89, 123),
+    CHEORWON("철원군", 12, 65, 139),
+    CHUNCHEON("춘천시", 13, 73, 134),
+    TAEBAEK("태백시", 14, 95, 119),
+    PYEONGCHANG("평창군", 15, 84, 123),
+    HONGCHEON("홍천군", 16, 75, 130),
+    HWACHEON("화천군", 17, 72, 139),
+    HOENGSEONG("횡성군", 18, 77, 125);
 
     private final String name;
     private final int code;
+
+    private final int nx; // 날씨 예보지점 X좌표
+    private final int ny; // 날씨 예보지점 Y좌표
 
     public static Sigungu getSigunguType(int code){
         return Arrays.stream(Sigungu.values())
@@ -40,6 +43,5 @@ public enum Sigungu {
                 .findFirst()
                 .orElseThrow(); // 예외 처리 필요
     }
-
 
 }


### PR DESCRIPTION
## 🔎 Description
- 공공데이터포털 - 기상청_단기예보 ((구)_동네예보) 조회서비스 API (초단기예보조회) 호출 및 프론트 응답 로직 구현

## 💭 Issue
- closed #93 

## 🗝 Key Changes
<!-- 주요 변경사항에 대해 작성해 주세요 -->
- API 호출을 통해 해당하는 웰니스 장소가 속하는 시군구의 날씨 정보를 조회합니다. 
이때 API에서 제공하는 정보를 적절히 분류하여 프론트에 응답합니다.
- 프론트에 제공하는 날씨 정보: 기온, 하늘 상태(맑음, 흐림, 비, 눈, 비/눈)
![image](https://github.com/user-attachments/assets/44ebb7df-07fa-4735-b31e-ef1f87b4930d)

<!-- ## 🙏 To Reviewers -->
<!-- 리뷰어 전달사항을 작성해 주세요 -->

