### PR TITLE
[fix #91] 리뷰 별점 중 하나라도 값이 있으면 조회되도록 수정

### DIFF
--- a/src/main/java/com/wellcome/WellcomeBE/domain/support/dto/SupportRequest.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/support/dto/SupportRequest.java
@@ -19,8 +19,7 @@ public class SupportRequest {
         private Long communityId;
 
         @NotNull(message = message)
-        @Size(min = 1, message = message)
-        private List<Long> wellnessInfoIds;  // wellnessInfo ID 리스트
+        private Long wellnessInfoId;  // wellnessInfo ID 리스트
     }
 
 

--- a/src/main/java/com/wellcome/WellcomeBE/domain/support/service/SupportService.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/support/service/SupportService.java
@@ -58,17 +58,16 @@ public class SupportService {
                 .orElseThrow(() -> new CustomException(CustomErrorCode.COMMUNITY_NOT_FOUND));
         Member member = tokenProvider.getMember();
 
-        req.getWellnessInfoIds().forEach(wellness -> {
-            // 웰니스 정보 존재 확인
-            WellnessInfo wellnessInfo = wellnessInfoRepository.findById(wellness).orElseThrow(() -> new CustomException(CustomErrorCode.WELLNESS_INFO_NOT_FOUND));
+        // 웰니스 정보 존재 확인
+        WellnessInfo wellnessInfo = wellnessInfoRepository.findById(req.getWellnessInfoId()).orElseThrow(() -> new CustomException(CustomErrorCode.WELLNESS_INFO_NOT_FOUND));
 
             // Support 조회 및 생성
-            supportRepository.findByMemberAndCommunityIdAndWellnessInfoId(member, req.getCommunityId() , wellness)
+            supportRepository.findByMemberAndCommunityIdAndWellnessInfoId(member, req.getCommunityId() , wellnessInfo.getId())
                     .orElseGet(() -> {
                         Support newSupport = Support.createWellnessInfoSupport(community, wellnessInfo, member);
                         return supportRepository.save(newSupport); // Support 생성 및 저장
                     });
-        });
+
     }
 
     @Transactional

--- a/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/repository/WellnessInfoRepository.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/wellnessInfo/repository/WellnessInfoRepository.java
@@ -134,8 +134,7 @@ public interface WellnessInfoRepository extends JpaRepository<WellnessInfo, Long
                     "LEFT JOIN Liked l ON l.wellnessInfo = w AND l.member = :member " +
                     "LEFT JOIN Support s ON s.wellnessInfo = w AND s.member = :member " +
                     "WHERE c.id = :communityId " +
-                    "AND tpp.review IS NOT NULL " +
-                    "AND tpp.rating IS NOT NULL"
+                    "AND (tpp.review IS NOT NULL OR tpp.rating IS NOT NULL)"
     )
     List<Object[]> findWellnessInfoWithSupportAndLikedByCommunityId(
             @Param("communityId") Long communityId,


### PR DESCRIPTION
## 🔎 Description
- FE요청에 따라 공감 단일값 추가로 변경
- 리뷰 별점 중 하나라도 값이 있으면 조회되도록 수정

## 💭 Issue
- closed #이슈번호

## 🗝 Key Changes
<!-- 주요 변경사항에 대해 작성해 주세요 -->
![image](https://github.com/user-attachments/assets/e7c15052-c807-436a-b7ef-1ec6d0184161)
![image](https://github.com/user-attachments/assets/df062032-f586-4407-bfa2-3dc41904fefb)
커뮤니티의 작성된 여행 폴더 중 리뷰 또는 별점 중 1개 이상 시 조회되고 리뷰와 별점 모두 없는 경우 조회되지 않습니다.

## 🙏 To Reviewers
<!-- 리뷰어 전달사항을 작성해 주세요 -->

