### PR TITLE
[fix #107] @PrePersist 어노테이션을 사용하여 엔티티가 DB에 저장되기 전에 status 필드에 값을 설정

### DIFF
--- a/src/main/java/com/wellcome/WellcomeBE/domain/tripPlanPlace/TripPlanPlace.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/tripPlanPlace/TripPlanPlace.java
@@ -29,11 +29,19 @@ public class TripPlanPlace extends BaseTimeEntity {
     private Integer rating;
     private String review;
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false, length = 10)
-    protected TripPlan.Status status = TripPlan.Status.ACTIVE; // 여행지 삭제 여부
+    @Column(nullable = false, columnDefinition = "ENUM('ACTIVE', 'INACTIVE') DEFAULT 'ACTIVE'")
+    private TripPlan.Status status;
 
     public enum Status {
         ACTIVE, INACTIVE;
+    }
+
+    // 엔티티가 DB에 저장되기 전에 호출되는 메서드
+    @PrePersist
+    public void prePersist() {
+        if (this.status == null) {
+            this.status = TripPlan.Status.ACTIVE; // 기본값 설정
+        }
     }
 
     public void updatePlaceReview(Integer rating, String review) {

--- a/src/main/java/com/wellcome/WellcomeBE/domain/tripPlanPlace/repository/TripPlanPlaceRepository.java
+++ b/src/main/java/com/wellcome/WellcomeBE/domain/tripPlanPlace/repository/TripPlanPlaceRepository.java
@@ -31,6 +31,7 @@ public interface TripPlanPlaceRepository extends JpaRepository<TripPlanPlace,Lon
             "JOIN FETCH tpp.wellnessInfo w " +
             "WHERE tpp.tripPlan.id = :planId " +
             "AND (:thema IS NULL OR tpp.wellnessInfo.thema = :thema) " +
+            "AND tpp.status = 'ACTIVE' " + // 상태가 ACTIVE인 조건 추가
             "ORDER BY tpp.createdAt DESC")
     Page<TripPlanPlace> findByTripPlanIdAndThema(PageRequest pageRequest,
                                                  @Param("planId") Long planId,


### PR DESCRIPTION
## 🔎 Description
- DB 컬럼 설정 시 기본값 ACTIVE 설정이 되어 있으나 JPA에서 데이터를 삽입할 때 status 필드가 null로 전달되면서 오류 발생

## 💭 Issue
- closed #이슈번호

## 🗝 Key Changes
<!-- 주요 변경사항에 대해 작성해 주세요 -->


## 🙏 To Reviewers
<!-- 리뷰어 전달사항을 작성해 주세요 -->

